### PR TITLE
Introduce service layer for domain controllers

### DIFF
--- a/src/main/java/com/pitty/controller/ClienteController.java
+++ b/src/main/java/com/pitty/controller/ClienteController.java
@@ -1,7 +1,7 @@
 package com.pitty.controller;
 
 import com.pitty.domain.Cliente;
-import com.pitty.repository.ClienteRepository;
+import com.pitty.service.ClienteService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,44 +13,40 @@ import java.util.List;
 @RequestMapping("/api/clientes")
 public class ClienteController {
 
-  private final ClienteRepository repo;
+  private final ClienteService service;
 
-  public ClienteController(ClienteRepository repo) {
-    this.repo = repo;
+  public ClienteController(ClienteService service) {
+    this.service = service;
   }
 
   @GetMapping
   public List<Cliente> findAll() {
-    return repo.findAll();
+    return service.findAll();
   }
 
   @GetMapping("/{id}")
   public ResponseEntity<Cliente> findOne(@PathVariable Long id) {
-    return repo.findById(id).map(ResponseEntity::ok)
+    return service.findById(id).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   @PostMapping
   public ResponseEntity<Cliente> create(@Valid @RequestBody Cliente body) {
-    var saved = repo.save(body);
+    var saved = service.create(body);
     return ResponseEntity.created(URI.create("/api/clientes/" + saved.getId())).body(saved);
   }
 
   @PutMapping("/{id}")
   public ResponseEntity<Cliente> update(@PathVariable Long id, @Valid @RequestBody Cliente body) {
-    return repo.findById(id).map(existing -> {
-      existing.setNombre(body.getNombre());
-      existing.setTelefono(body.getTelefono());
-      existing.setNotas(body.getNotas());
-      existing.setUpdatedBy(body.getUpdatedBy());
-      return ResponseEntity.ok(repo.save(existing));
-    }).orElseGet(() -> ResponseEntity.notFound().build());
+    return service
+        .update(id, body)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> delete(@PathVariable Long id) {
-    if (!repo.existsById(id)) return ResponseEntity.notFound().build();
-    repo.deleteById(id);
+    if (!service.delete(id)) return ResponseEntity.notFound().build();
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/pitty/controller/IngredienteController.java
+++ b/src/main/java/com/pitty/controller/IngredienteController.java
@@ -1,7 +1,7 @@
 package com.pitty.controller;
 
 import com.pitty.domain.Ingrediente;
-import com.pitty.repository.IngredienteRepository;
+import com.pitty.service.IngredienteService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,22 +13,23 @@ import java.util.List;
 @RequestMapping("/api/ingredientes")
 public class IngredienteController {
 
-  private final IngredienteRepository repo;
+  private final IngredienteService service;
 
-  public IngredienteController(IngredienteRepository repo) {
-    this.repo = repo;
+  public IngredienteController(IngredienteService service) {
+    this.service = service;
   }
 
   // GET /api/ingredientes
   @GetMapping
   public List<Ingrediente> findAll() {
-    return repo.findAll();
+    return service.findAll();
   }
 
   // GET /api/ingredientes/{id}
   @GetMapping("/{id}")
   public ResponseEntity<Ingrediente> findOne(@PathVariable Long id) {
-    return repo.findById(id)
+    return service
+        .findById(id)
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
   }
@@ -37,32 +38,23 @@ public class IngredienteController {
   @PostMapping
   public ResponseEntity<Ingrediente> create(@Valid @RequestBody Ingrediente body) {
     // createdAt/updatedAt se llenan por @PrePersist en Auditable
-    var saved = repo.save(body);
+    var saved = service.create(body);
     return ResponseEntity.created(URI.create("/api/ingredientes/" + saved.getId())).body(saved);
   }
 
   // PUT /api/ingredientes/{id}
   @PutMapping("/{id}")
   public ResponseEntity<Ingrediente> update(@PathVariable Long id, @Valid @RequestBody Ingrediente body) {
-    return repo.findById(id)
-        .map(existing -> {
-          existing.setNombre(body.getNombre());
-          existing.setUnidad(body.getUnidad());
-          existing.setStockActual(body.getStockActual());
-          existing.setStockMinimo(body.getStockMinimo());
-          existing.setActivo(body.getActivo());
-          existing.setUpdatedBy(body.getUpdatedBy());
-          var saved = repo.save(existing);
-          return ResponseEntity.ok(saved);
-        })
+    return service
+        .update(id, body)
+        .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   // DELETE /api/ingredientes/{id}
   @DeleteMapping("/{id}")
   public ResponseEntity<Void> delete(@PathVariable Long id) {
-    if (!repo.existsById(id)) return ResponseEntity.notFound().build();
-    repo.deleteById(id);
+    if (!service.delete(id)) return ResponseEntity.notFound().build();
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/pitty/controller/PostreController.java
+++ b/src/main/java/com/pitty/controller/PostreController.java
@@ -1,7 +1,7 @@
 package com.pitty.controller;
 
 import com.pitty.domain.Postre;
-import com.pitty.repository.PostreRepository;
+import com.pitty.service.PostreService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,22 +12,22 @@ import java.util.List;
 @RequestMapping("/api/postres")
 public class PostreController {
 
-  private final PostreRepository repo;
+  private final PostreService service;
 
-  public PostreController(PostreRepository repo) { this.repo = repo; }
+  public PostreController(PostreService service) { this.service = service; }
 
   @GetMapping
-  public List<Postre> all() { return repo.findAll(); }
+  public List<Postre> all() { return service.findAll(); }
 
   @GetMapping("/{id}")
   public ResponseEntity<Postre> one(@PathVariable Long id) {
-    return repo.findById(id).map(ResponseEntity::ok)
+    return service.findById(id).map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   @PostMapping
   public ResponseEntity<Postre> create(@RequestBody Postre body) {
-    var saved = repo.save(body);
+    var saved = service.create(body);
     return ResponseEntity.created(URI.create("/api/postres/" + saved.getId())).body(saved);
   }
 }

--- a/src/main/java/com/pitty/service/ClienteService.java
+++ b/src/main/java/com/pitty/service/ClienteService.java
@@ -1,0 +1,56 @@
+package com.pitty.service;
+
+import com.pitty.domain.Cliente;
+import com.pitty.repository.ClienteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ClienteService {
+
+  private final ClienteRepository repository;
+
+  public ClienteService(ClienteRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Cliente> findAll() {
+    return repository.findAll();
+  }
+
+  public Optional<Cliente> findById(Long id) {
+    return repository.findById(id);
+  }
+
+  @Transactional
+  public Cliente create(Cliente cliente) {
+    return repository.save(cliente);
+  }
+
+  @Transactional
+  public Optional<Cliente> update(Long id, Cliente body) {
+    return repository
+        .findById(id)
+        .map(
+            existing -> {
+              existing.setNombre(body.getNombre());
+              existing.setTelefono(body.getTelefono());
+              existing.setNotas(body.getNotas());
+              existing.setUpdatedBy(body.getUpdatedBy());
+              return repository.save(existing);
+            });
+  }
+
+  @Transactional
+  public boolean delete(Long id) {
+    if (!repository.existsById(id)) {
+      return false;
+    }
+    repository.deleteById(id);
+    return true;
+  }
+}
+

--- a/src/main/java/com/pitty/service/IngredienteService.java
+++ b/src/main/java/com/pitty/service/IngredienteService.java
@@ -1,0 +1,58 @@
+package com.pitty.service;
+
+import com.pitty.domain.Ingrediente;
+import com.pitty.repository.IngredienteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class IngredienteService {
+
+  private final IngredienteRepository repository;
+
+  public IngredienteService(IngredienteRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Ingrediente> findAll() {
+    return repository.findAll();
+  }
+
+  public Optional<Ingrediente> findById(Long id) {
+    return repository.findById(id);
+  }
+
+  @Transactional
+  public Ingrediente create(Ingrediente body) {
+    return repository.save(body);
+  }
+
+  @Transactional
+  public Optional<Ingrediente> update(Long id, Ingrediente body) {
+    return repository
+        .findById(id)
+        .map(
+            existing -> {
+              existing.setNombre(body.getNombre());
+              existing.setUnidad(body.getUnidad());
+              existing.setStockActual(body.getStockActual());
+              existing.setStockMinimo(body.getStockMinimo());
+              existing.setActivo(body.getActivo());
+              existing.setUpdatedBy(body.getUpdatedBy());
+              return repository.save(existing);
+            });
+  }
+
+  @Transactional
+  public boolean delete(Long id) {
+    if (!repository.existsById(id)) {
+      return false;
+    }
+    repository.deleteById(id);
+    return true;
+  }
+}
+

--- a/src/main/java/com/pitty/service/PedidoService.java
+++ b/src/main/java/com/pitty/service/PedidoService.java
@@ -1,0 +1,97 @@
+package com.pitty.service;
+
+import com.pitty.domain.Cliente;
+import com.pitty.domain.Pedido;
+import com.pitty.domain.PedidoItem;
+import com.pitty.domain.Postre;
+import com.pitty.dto.PedidoCreateDTO;
+import com.pitty.dto.PedidoItemCreateDTO;
+import com.pitty.repository.ClienteRepository;
+import com.pitty.repository.PedidoItemRepository;
+import com.pitty.repository.PedidoRepository;
+import com.pitty.repository.PostreRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PedidoService {
+
+  private final PedidoRepository pedidoRepository;
+  private final PedidoItemRepository itemRepository;
+  private final ClienteRepository clienteRepository;
+  private final PostreRepository postreRepository;
+
+  public PedidoService(
+      PedidoRepository pedidoRepository,
+      PedidoItemRepository itemRepository,
+      ClienteRepository clienteRepository,
+      PostreRepository postreRepository) {
+    this.pedidoRepository = pedidoRepository;
+    this.itemRepository = itemRepository;
+    this.clienteRepository = clienteRepository;
+    this.postreRepository = postreRepository;
+  }
+
+  public List<Pedido> findAll() {
+    return pedidoRepository.findAll();
+  }
+
+  public Optional<Pedido> findById(Long id) {
+    return pedidoRepository.findById(id);
+  }
+
+  @Transactional
+  public Pedido create(PedidoCreateDTO dto) {
+    Cliente cliente =
+        Optional.ofNullable(dto.getClienteId())
+            .flatMap(clienteRepository::findById)
+            .orElseThrow(() -> new IllegalArgumentException("Cliente inexistente"));
+
+    if (dto.getItems() == null || dto.getItems().isEmpty()) {
+      throw new IllegalArgumentException("El pedido debe incluir al menos un item");
+    }
+
+    Pedido pedido = new Pedido();
+    pedido.setCliente(cliente);
+    pedido.setFechaEntrega(dto.getFechaEntrega());
+    pedido.setEstado(Pedido.Estado.BORRADOR);
+    pedido.setNotas(dto.getNotas());
+    pedido.setTotal(BigDecimal.ZERO);
+    pedido = pedidoRepository.save(pedido);
+
+    BigDecimal total = BigDecimal.ZERO;
+    for (PedidoItemCreateDTO itemDTO : dto.getItems()) {
+      Postre postre =
+          Optional.ofNullable(itemDTO.getPostreId())
+              .flatMap(postreRepository::findById)
+              .orElseThrow(() -> new IllegalArgumentException("Postre inexistente"));
+
+      if (itemDTO.getCantidad() == null || itemDTO.getCantidad() <= 0) {
+        throw new IllegalArgumentException("La cantidad debe ser mayor a cero");
+      }
+      if (itemDTO.getPrecioUnitario() == null || itemDTO.getPrecioUnitario().signum() < 0) {
+        throw new IllegalArgumentException("El precio unitario debe ser positivo");
+      }
+
+      PedidoItem item = new PedidoItem();
+      item.setPedido(pedido);
+      item.setPostre(postre);
+      item.setCantidad(itemDTO.getCantidad());
+      item.setPrecioUnitario(itemDTO.getPrecioUnitario());
+      BigDecimal subtotal = itemDTO.getPrecioUnitario().multiply(new BigDecimal(itemDTO.getCantidad()));
+      item.setSubtotal(subtotal);
+      item.setPersonalizaciones(itemDTO.getPersonalizaciones());
+      itemRepository.save(item);
+
+      total = total.add(subtotal);
+    }
+
+    pedido.setTotal(total);
+    return pedidoRepository.save(pedido);
+  }
+}
+

--- a/src/main/java/com/pitty/service/PostreService.java
+++ b/src/main/java/com/pitty/service/PostreService.java
@@ -1,0 +1,33 @@
+package com.pitty.service;
+
+import com.pitty.domain.Postre;
+import com.pitty.repository.PostreRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PostreService {
+
+  private final PostreRepository repository;
+
+  public PostreService(PostreRepository repository) {
+    this.repository = repository;
+  }
+
+  public List<Postre> findAll() {
+    return repository.findAll();
+  }
+
+  public Optional<Postre> findById(Long id) {
+    return repository.findById(id);
+  }
+
+  @Transactional
+  public Postre create(Postre body) {
+    return repository.save(body);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated services for clientes, ingredientes, postres y pedidos con anotaciones `@Service` y métodos CRUD transaccionales
- mover la lógica de negocio existente desde los controladores hacia los nuevos servicios, añadiendo validaciones para pedidos
- actualizar los controladores para depender de los servicios en lugar de los repositorios directos

## Testing
- mvn test *(falla: Maven no pudo descargar el parent POM debido a un 403 desde repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68dc289817d8832a93e3ce2e442a8161